### PR TITLE
Improve print action configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,33 @@
 # UOFlow
-A UI mod for Ultima Online Enhanced Client for macro enhancements
 
-Ultima Online's Enhanced Client has a lot of potential for the macro system to be very useful. The intention here is to enhance the macro system by adding more automation functionality like looping, variables, and conditional statements.
+UOFlow is a UI modification for the **Ultima Online Enhanced Client** focused on expanding the game's built in macro and automation functionality. The goal is to make complex actions possible directly within the client through a visual programming interface written in Lua.
+
+## Features
+
+- Custom visual programming interface for building in-game logic
+- Extensible action and trigger system written in Lua
+- Support for user made macros and enhanced context menus
+- Modular design allowing additional UI components to be added over time
+
+### Sample Actions
+
+- **Print Message** – outputs text to the debug console, chat window or overhead depending on user selection
+
+## Repository Layout
+
+- `UOFlow/` – Core mod files, Lua sources and interface XML definitions
+- `UOFlow/Source/` – Main Lua scripts for UI windows, macros and the visual programming system
+- `UOFlow/Source/UOFlow/` – Implementation of the visual programming interface
+- `Anarchy` – Example configuration XML shipped with the mod
+
+## Usage
+
+These files are intended to be placed inside the `UserInterface` folder of your Ultima Online installation. After copying, start the Enhanced Client and select the *UOFlow* UI in the options menu.
+
+Development of this project is Lua based and does not currently include an automated build system. Most files can be edited directly and reloaded by restarting the client.
+
+## Contributing
+
+Pull requests are welcome. See the TODO list for planned improvements. When adding new features make sure Lua scripts remain syntax compatible with Lua 5.1 which the client uses.
+
+

--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,21 @@
+# TODO
+
+This file lists planned enhancements for the UOFlow project.
+
+## Visual Programming System
+- Implement execution of complex control flow blocks such as loops and conditional branches.
+- Add a library of common actions (e.g. casting spells, item use, movement).
+- Provide better error reporting and debugging output when executing flows.
+- Improve the block editor UI with drag and drop placement and context menus.
+
+## Macro Enhancements
+- Support variables within macros that persist across sessions.
+- Allow macros to loop or repeat based on conditions.
+- Expose additional in-game events for macro triggers.
+
+## General
+- Write comprehensive documentation for each Lua module.
+- Add unit tests for key Lua functions once a test framework is in place.
+- Provide a sample configuration demonstrating common workflows.
+
+Contributions are welcome! Feel free to pick an item and submit a pull request.

--- a/UOFlow/Source/UOFlow/VisualProgrammingActions.lua
+++ b/UOFlow/Source/UOFlow/VisualProgrammingActions.lua
@@ -173,7 +173,33 @@ function VisualProgrammingInterface.Actions:initialize()
             return true
         end
     })
-    
+
+    -- Simple action that prints a message using a chosen destination
+    self:register({
+        name = "Print Message",
+        description = "Output text to console, chat or overhead",
+        category = self.categories.GENERAL,
+        icon = "Icons/actions/command.dds",
+        params = {
+            CreateParameter("text", ParameterType.STRING, "Hello"),
+            CreateParameter("destination", ParameterType.SELECT, "Console",
+                {"Console", "Chat", "Overhead"})
+        },
+        execute = function(params)
+            local dest = params.destination
+            if dest == "Chat" then
+                local channel = ChatSettings.Channels[SystemData.ChatLogFilters.SAY]
+                SendChat(channel, towstring(params.text))
+            elseif dest == "Overhead" then
+                WindowUtils.SendOverheadText(towstring(params.text), 66, true)
+            else
+                Debug.Print(tostring(params.text))
+            end
+            return true
+        end
+    })
+
+
     Debug.Print("Action system initialized")
 end
 
@@ -354,6 +380,31 @@ function VisualProgrammingInterface.Actions:initialize()
             return true
         end
     })
-    
+
+    -- Simple action that prints a message using a chosen destination
+    self:register({
+        name = "Print Message",
+        description = "Output text to console, chat or overhead",
+        category = self.categories.GENERAL,
+        icon = "Icons/actions/command.dds",
+        params = {
+            CreateParameter("text", ParameterType.STRING, "Hello"),
+            CreateParameter("destination", ParameterType.SELECT, "Console",
+                {"Console", "Chat", "Overhead"})
+        },
+        execute = function(params)
+            local dest = params.destination
+            if dest == "Chat" then
+                local channel = ChatSettings.Channels[SystemData.ChatLogFilters.SAY]
+                SendChat(channel, towstring(params.text))
+            elseif dest == "Overhead" then
+                WindowUtils.SendOverheadText(towstring(params.text), 66, true)
+            else
+                Debug.Print(tostring(params.text))
+            end
+            return true
+        end
+    })
+
     Debug.Print("Action system initialized")
 end


### PR DESCRIPTION
## Summary
- document example Print Message action in README
- allow Print Message action to print to console, chat or overhead
- switch icon to `command.dds`

## Testing
- `luac -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b9a4dcd3c8332baa0c136737c4f9b