### PR TITLE
Improve pattern scanning

### DIFF
--- a/UOWalkPatch/CMakeLists.txt
+++ b/UOWalkPatch/CMakeLists.txt
@@ -14,21 +14,10 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 # Static linking flags
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++")
 
-# Download and include nlohmann/json as a header-only library
-include(FetchContent)
-FetchContent_Declare(
-    json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.hpp
-    DOWNLOAD_NO_EXTRACT TRUE
-)
-FetchContent_MakeAvailable(json)
 
-# Create include directory and copy json.hpp there
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/include/nlohmann)
-file(COPY ${json_SOURCE_DIR}/json.hpp DESTINATION ${CMAKE_BINARY_DIR}/include/nlohmann)
 
 add_executable(UOWalkPatch src/main.cpp)
-target_include_directories(UOWalkPatch PRIVATE include ${CMAKE_BINARY_DIR}/include)
+target_include_directories(UOWalkPatch PRIVATE include)
 target_link_libraries(UOWalkPatch PRIVATE psapi)
 
 # Copy required JSON files to build directory

--- a/UOWalkPatch/include/stub_bin.h
+++ b/UOWalkPatch/include/stub_bin.h
@@ -1,4 +1,66 @@
 #pragma once
-// Placeholder stub that simply returns.
-static const unsigned char stub_bin[] = { 0xC3 };
-static const unsigned int stub_bin_len = sizeof(stub_bin);
+
+// Template for the remote thread. Addresses for the string name, bridge
+// function, lua_State pointer and RegisterLuaFunction are patched in at
+// runtime before the stub is written to the remote process.
+static const unsigned char stub_template[] = {
+    0x55, 0x89, 0xE5,                         // push ebp; mov ebp, esp
+    0x68, 0x00, 0x00, 0x00, 0x00,             // push name ptr (patched)
+    0x68, 0x00, 0x00, 0x00, 0x00,             // push bridge ptr (patched)
+    0x68, 0x00, 0x00, 0x00, 0x00,             // push lua_State* (patched)
+    0xB8, 0x00, 0x00, 0x00, 0x00,             // mov eax, RegisterLuaFunction (patched)
+    0xFF, 0xD0,                               // call eax
+    0x83, 0xC4, 0x0C,                         // add esp, 0xC
+    0x5D,                                     // pop ebp
+    0xC2, 0x04, 0x00                          // ret 4
+};
+
+static const unsigned int STUB_NAME_OFF   = 4;
+static const unsigned int STUB_BRIDGE_OFF = 9;
+static const unsigned int STUB_STATE_OFF  = 14;
+static const unsigned int STUB_REG_OFF    = 19;
+static const unsigned int stub_template_len = sizeof(stub_template);
+
+static const unsigned char bridge_stub[] = { 0x31, 0xC0, 0xC3 }; // xor eax,eax; ret
+static const unsigned int bridge_stub_len = sizeof(bridge_stub);
+
+// Hook stub that intercepts the RegisterLuaFunction call during client
+// startup. It first calls the original function, then registers a list of
+// additional natives using the same lua_State pointer. The stub executes only
+// once thanks to a flag stored in remote memory.
+static const unsigned char hook_stub_template[] = {
+    0x53,                         // push ebx
+    0x57,                         // push edi
+    0x89, 0xF3,                   // mov  ebx, esi
+    0xB8, 0,0,0,0,                // mov  eax, RegisterLuaFunction (patched)
+    0xFF, 0xD0,                   // call eax
+    0x89, 0xDE,                   // mov  esi, ebx
+    0xA1, 0,0,0,0,                // mov  eax, [executed flag] (patched)
+    0x83, 0x38, 0x00,             // cmp  dword ptr [eax], 0
+    0x75, 0x27,                   // jne  skip_register
+    0xC7, 0x00, 0x01,0x00,0x00,0x00, // mov dword ptr [eax],1
+    0xB9, 0,0,0,0,                // mov  ecx, numFuncs (patched)
+    0xBF, 0,0,0,0,                // mov  edi, funcs array (patched)
+    0x85, 0xC9,                   // test ecx, ecx
+    0x74, 0x13,                   // jz   done
+    0xFF, 0x37,                   // push dword ptr [edi]
+    0xFF, 0x77, 0x04,             // push dword ptr [edi+4]
+    0x56,                         // push esi
+    0xB8, 0,0,0,0,                // mov  eax, RegisterLuaFunction (patched)
+    0xFF, 0xD0,                   // call eax
+    0x83, 0xC7, 0x08,             // add  edi, 8
+    0x49,                         // dec  ecx
+    0x75, 0xE9,                   // jnz  loop
+    0x5F,                         // done: pop edi
+    0x5B,                         // pop ebx
+    0xB8, 0,0,0,0,                // mov  eax, return address (patched)
+    0xFF, 0xE0                    // jmp  eax
+};
+
+static const unsigned int HOOK_REG_OFF1   = 5;
+static const unsigned int HOOK_FLAG_OFF   = 14;
+static const unsigned int HOOK_NUM_OFF    = 30;
+static const unsigned int HOOK_FUNCS_OFF  = 35;
+static const unsigned int HOOK_REG_OFF2   = 50;
+static const unsigned int HOOK_RET_OFF    = 65;
+static const unsigned int hook_stub_template_len = sizeof(hook_stub_template);


### PR DESCRIPTION
## Summary
- added `<cstdint>` and `<cstring>` includes for proper types and memcpy
- avoid missing matches across chunk boundaries when scanning
- create hook stub for early registration
- launch UOSA in suspended mode and install hook before resuming

## Testing
- `cmake ..`
- `cmake --build .` *(fails: x86_64-w64-mingw32-g++ missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f748551608332bb76337e1fd6a9cf