### PR TITLE
Improve helper lifecycle

### DIFF
--- a/UOWalkPatch/CMakeLists.txt
+++ b/UOWalkPatch/CMakeLists.txt
@@ -14,21 +14,10 @@ set(CMAKE_FIND_ROOT_PATH_MODE_INCLUDE ONLY)
 # Static linking flags
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -static -static-libgcc -static-libstdc++")
 
-# Download and include nlohmann/json as a header-only library
-include(FetchContent)
-FetchContent_Declare(
-    json
-    URL https://github.com/nlohmann/json/releases/download/v3.11.3/json.hpp
-    DOWNLOAD_NO_EXTRACT TRUE
-)
-FetchContent_MakeAvailable(json)
 
-# Create include directory and copy json.hpp there
-file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/include/nlohmann)
-file(COPY ${json_SOURCE_DIR}/json.hpp DESTINATION ${CMAKE_BINARY_DIR}/include/nlohmann)
 
 add_executable(UOWalkPatch src/main.cpp)
-target_include_directories(UOWalkPatch PRIVATE include ${CMAKE_BINARY_DIR}/include)
+target_include_directories(UOWalkPatch PRIVATE include)
 target_link_libraries(UOWalkPatch PRIVATE psapi)
 
 # Copy required JSON files to build directory

--- a/UOWalkPatch/README.md
+++ b/UOWalkPatch/README.md
@@ -11,4 +11,10 @@ cmake ..
 make
 ```
 
-The resulting `UOWalkPatch.exe` should be run after the client is started. It will search for `uosa.exe`, allocate memory for the stub and spawn a remote thread. A debug console pops up showing pattern matches and other status messages.
+Run `UOWalkPatch.exe` after the client is already running. The tool attaches to
+`uosa.exe`, locates the hidden `RegisterLuaFunction` routine and the global
+`lua_State` pointer, then registers any functions described in
+`signatures.json`.  A small monitoring thread stays alive and watches for the
+UI being reloaded (when the `lua_State` pointer changes) so the natives are
+re-registered automatically.  A debug console pops up showing pattern matches
+and other status messages. Press **Enter** to stop the helper.

--- a/UOWalkPatch/include/stub_bin.h
+++ b/UOWalkPatch/include/stub_bin.h
@@ -1,4 +1,73 @@
 #pragma once
-// Placeholder stub that simply returns.
-static const unsigned char stub_bin[] = { 0xC3 };
-static const unsigned int stub_bin_len = sizeof(stub_bin);
+
+// Template for the remote thread. Addresses for the string name, bridge
+// function, lua_State pointer and RegisterLuaFunction are patched in at
+// runtime before the stub is written to the remote process.
+static const unsigned char stub_template[] = {
+    0x55, 0x89, 0xE5,                         // push ebp; mov ebp, esp
+    0x68, 0x00, 0x00, 0x00, 0x00,             // push name ptr (patched)
+    0x68, 0x00, 0x00, 0x00, 0x00,             // push bridge ptr (patched)
+    0x68, 0x00, 0x00, 0x00, 0x00,             // push lua_State* (patched)
+    0xB8, 0x00, 0x00, 0x00, 0x00,             // mov eax, RegisterLuaFunction (patched)
+    0xFF, 0xD0,                               // call eax
+    0x83, 0xC4, 0x0C,                         // add esp, 0xC
+    0x5D,                                     // pop ebp
+    0xC2, 0x04, 0x00                          // ret 4
+};
+
+static const unsigned int STUB_NAME_OFF   = 4;
+static const unsigned int STUB_BRIDGE_OFF = 9;
+static const unsigned int STUB_STATE_OFF  = 14;
+static const unsigned int STUB_REG_OFF    = 19;
+static const unsigned int stub_template_len = sizeof(stub_template);
+
+// Template for a bridge that simply jumps to a builtin function. The builtin
+// address is patched at runtime.
+static const unsigned char bridge_template[] = {
+    0xB8, 0x00, 0x00, 0x00, 0x00, // mov eax, <builtin>
+    0xFF, 0xE0                    // jmp eax
+};
+
+static const unsigned int BRIDGE_FUNC_OFF = 1;
+static const unsigned int bridge_template_len = sizeof(bridge_template);
+
+// Hook stub that intercepts the RegisterLuaFunction call during client
+// startup. It first calls the original function, then registers a list of
+// additional natives using the same lua_State pointer. The stub executes only
+// once thanks to a flag stored in remote memory.
+static const unsigned char hook_stub_template[] = {
+    0x53,                         // push ebx
+    0x57,                         // push edi
+    0x89, 0xF3,                   // mov  ebx, esi
+    0xB8, 0,0,0,0,                // mov  eax, RegisterLuaFunction (patched)
+    0xFF, 0xD0,                   // call eax
+    0x89, 0xDE,                   // mov  esi, ebx
+    0xA1, 0,0,0,0,                // mov  eax, [executed flag] (patched)
+    0x83, 0x38, 0x00,             // cmp  dword ptr [eax], 0
+    0x75, 0x27,                   // jne  skip_register
+    0xC7, 0x00, 0x01,0x00,0x00,0x00, // mov dword ptr [eax],1
+    0xB9, 0,0,0,0,                // mov  ecx, numFuncs (patched)
+    0xBF, 0,0,0,0,                // mov  edi, funcs array (patched)
+    0x85, 0xC9,                   // test ecx, ecx
+    0x74, 0x13,                   // jz   done
+    0xFF, 0x37,                   // push dword ptr [edi]
+    0xFF, 0x77, 0x04,             // push dword ptr [edi+4]
+    0x56,                         // push esi
+    0xB8, 0,0,0,0,                // mov  eax, RegisterLuaFunction (patched)
+    0xFF, 0xD0,                   // call eax
+    0x83, 0xC7, 0x08,             // add  edi, 8
+    0x49,                         // dec  ecx
+    0x75, 0xE9,                   // jnz  loop
+    0x5F,                         // done: pop edi
+    0x5B,                         // pop ebx
+    0xB8, 0,0,0,0,                // mov  eax, return address (patched)
+    0xFF, 0xE0                    // jmp  eax
+};
+
+static const unsigned int HOOK_REG_OFF1   = 5;
+static const unsigned int HOOK_FLAG_OFF   = 14;
+static const unsigned int HOOK_NUM_OFF    = 30;
+static const unsigned int HOOK_FUNCS_OFF  = 35;
+static const unsigned int HOOK_REG_OFF2   = 50;
+static const unsigned int HOOK_RET_OFF    = 65;
+static const unsigned int hook_stub_template_len = sizeof(hook_stub_template);

--- a/UOWalkPatch/src/main.cpp
+++ b/UOWalkPatch/src/main.cpp
@@ -8,10 +8,10 @@
 #include <string>
 #include <algorithm>
 #include "stub_bin.h"
-#include <nlohmann/json.hpp>
+#include <cstdint>
+#include <cstring>
 #include <sstream>
-
-using json = nlohmann::json;
+#include <regex>
 
 namespace {
     std::ofstream log_file;
@@ -72,13 +72,6 @@ namespace {
     }
 }
 
-struct Signature {
-    std::string lua_name;
-    std::string pattern;
-    std::string bridge;
-    uintptr_t address{0};
-};
-
 struct PatternData {
     std::vector<uint8_t> bytes;
     std::string mask;
@@ -100,6 +93,34 @@ PatternData parsePattern(const std::string& pat) {
         }
     }
     return out;
+}
+
+struct Signature {
+    std::string lua_name;
+    std::string pattern;
+    std::string bridge;
+    uintptr_t address{0};
+};
+
+bool loadSignatures(const std::string& path, std::vector<Signature>& out) {
+    std::ifstream f(path);
+    if (!f.is_open()) {
+        std::cerr << "failed to open signatures.json\n";
+        return false;
+    }
+    std::string data((std::istreambuf_iterator<char>(f)), {});
+    std::regex func_re(R"(\{[^\}]*\"lua_name\"\s*:\s*\"([^\"]+)\"[^\}]*\"pattern\"\s*:\s*\"([^\"]+)\"[^\}]*\"bridge\"\s*:\s*\"([^\"]+)\")");
+    std::smatch m;
+    auto it = data.cbegin();
+    while (std::regex_search(it, data.cend(), m, func_re)) {
+        Signature s;
+        s.lua_name = m[1];
+        s.pattern  = m[2];
+        s.bridge   = m[3];
+        out.push_back(s);
+        it = m.suffix().first;
+    }
+    return !out.empty();
 }
 
 bool isLikelyCodeRegion(const MEMORY_BASIC_INFORMATION& mbi) {
@@ -181,10 +202,11 @@ bool scanProcess(HANDLE proc, const PatternData& pat, uintptr_t& found) {
 
     try {
         const size_t CHUNK_SIZE = 4096;  // Read in 4KB chunks
+        const size_t STEP_SIZE = CHUNK_SIZE - pat.bytes.size() + 1;
         size_t bytesScanned = 0;
         std::vector<uint8_t> buffer(CHUNK_SIZE);
 
-        for (uintptr_t addr = start; addr < end; addr += CHUNK_SIZE) {
+        for (uintptr_t addr = start; addr < end; addr += STEP_SIZE) {
             size_t toRead = std::min<size_t>(CHUNK_SIZE, end - addr);
             
             SIZE_T read;
@@ -239,22 +261,76 @@ bool scanProcess(HANDLE proc, const PatternData& pat, uintptr_t& found) {
     return false;
 }
 
-bool loadSignatures(const std::string& path, std::vector<Signature>& out) {
-    std::ifstream f(path);
-    if (!f.is_open()) {
-        std::cerr << "failed to open signatures.json\n";
+// Scan for a raw byte sequence (used for string searches)
+bool scanForBytes(HANDLE proc, const std::vector<uint8_t>& bytes, uintptr_t& found) {
+    PatternData pd;
+    pd.bytes = bytes;
+    pd.mask.assign(bytes.size(), 'x');
+    return scanProcess(proc, pd, found);
+}
+
+bool scanForString(HANDLE proc, const std::string& str, uintptr_t& found) {
+    std::vector<uint8_t> bytes(str.begin(), str.end());
+    bytes.push_back('\0');
+    return scanForBytes(proc, bytes, found);
+}
+
+bool findPushWithAddress(HANDLE proc, uintptr_t addr, uintptr_t& pushAddr) {
+    std::vector<uint8_t> pat(5);
+    pat[0] = 0x68; // push imm32
+    std::memcpy(&pat[1], &addr, 4);
+    return scanForBytes(proc, pat, pushAddr);
+}
+
+bool findRegisterLuaFunction(HANDLE proc, uintptr_t& regOut, uintptr_t& callSiteOut) {
+    uintptr_t strAddr = 0;
+    if (!scanForString(proc, "GetBuildVersion", strAddr)) {
+        debug_log("GetBuildVersion string not found");
         return false;
     }
-    json j; f >> j;
-    for (const auto& item : j["functions"]) {
-        Signature s;
-        s.lua_name = item["lua_name"].get<std::string>();
-        s.pattern = item["pattern"].get<std::string>();
-        s.bridge = item["bridge"].get<std::string>();
-        out.push_back(s);
+    debug_log("GetBuildVersion string at 0x" + [&]{std::ostringstream oss; oss<<std::hex<<strAddr; return oss.str();}());
+
+    uintptr_t pushAddr = 0;
+    if (!findPushWithAddress(proc, strAddr, pushAddr)) {
+        debug_log("push instruction for GetBuildVersion not found");
+        return false;
     }
+    debug_log("push of GetBuildVersion found at 0x" + [&]{std::ostringstream oss; oss<<std::hex<<pushAddr; return oss.str();}());
+
+    uintptr_t callAddr = pushAddr + 11; // push str, push impl, push esi, call
+    uint8_t opcode = 0;
+    SIZE_T read = 0;
+    if (!ReadProcessMemory(proc, (LPCVOID)callAddr, &opcode, 1, &read) || opcode != 0xE8) {
+        debug_log("expected call opcode not found");
+        return false;
+    }
+    int32_t rel = 0;
+    if (!ReadProcessMemory(proc, (LPCVOID)(callAddr + 1), &rel, 4, &read)) {
+        debug_log("failed to read relative offset");
+        return false;
+    }
+    regOut = callAddr + 5 + rel;
+    callSiteOut = callAddr;
+    debug_log("RegisterLuaFunction at 0x" + [&]{std::ostringstream oss; oss<<std::hex<<regOut; return oss.str();}());
     return true;
 }
+
+bool findLuaStatePtr(HANDLE proc, uintptr_t& out) {
+    PatternData pat = parsePattern("A1 ?? ?? ?? ?? 85 C0 75 ?? 8B 08");
+    uintptr_t match = 0;
+    if (!scanProcess(proc, pat, match)) {
+        debug_log("LuaState pattern not found");
+        return false;
+    }
+    SIZE_T read = 0;
+    if (!ReadProcessMemory(proc, (LPCVOID)(match + 1), &out, 4, &read)) {
+        debug_log("failed to read LuaState pointer address");
+        return false;
+    }
+    debug_log("LuaState global at 0x" + [&]{std::ostringstream oss; oss<<std::hex<<out; return oss.str();}());
+    return true;
+}
+
 
 DWORD findProcess(const std::wstring& name) {
     DWORD pid = 0;
@@ -341,47 +417,81 @@ bool enableDebugPrivilege() {
     return true;
 }
 
+struct RemoteFuncInfo {
+    uint32_t nameAddr;
+    uint32_t bridgeAddr;
+};
+
+struct MonitorContext {
+    HANDLE process;
+    uintptr_t luaStatePtrAddr;
+    uintptr_t registerFunc;
+    std::vector<RemoteFuncInfo> funcs;
+    volatile bool running{true};
+};
+
+bool registerFunction(HANDLE proc, const RemoteFuncInfo& info,
+                      uintptr_t luaState, uintptr_t regFunc) {
+    std::vector<uint8_t> stub(stub_template, stub_template + stub_template_len);
+    *(uint32_t*)&stub[STUB_NAME_OFF]   = info.nameAddr;
+    *(uint32_t*)&stub[STUB_BRIDGE_OFF] = info.bridgeAddr;
+    *(uint32_t*)&stub[STUB_STATE_OFF]  = (uint32_t)luaState;
+    *(uint32_t*)&stub[STUB_REG_OFF]    = (uint32_t)regFunc;
+
+    void* remote = VirtualAllocEx(proc, nullptr, stub.size(), MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+    if (!remote) return false;
+    SIZE_T written = 0;
+    WriteProcessMemory(proc, remote, stub.data(), stub.size(), &written);
+    HANDLE th = CreateRemoteThread(proc, nullptr, 0, (LPTHREAD_START_ROUTINE)remote, nullptr, 0, nullptr);
+    if (!th) {
+        VirtualFreeEx(proc, remote, 0, MEM_RELEASE);
+        return false;
+    }
+    WaitForSingleObject(th, INFINITE);
+    CloseHandle(th);
+    VirtualFreeEx(proc, remote, 0, MEM_RELEASE);
+    return true;
+}
+
+DWORD WINAPI monitorThread(LPVOID param) {
+    MonitorContext* ctx = reinterpret_cast<MonitorContext*>(param);
+    uintptr_t lastState = 0;
+    while (ctx->running) {
+        uintptr_t state = 0;
+        SIZE_T read = 0;
+        ReadProcessMemory(ctx->process, (LPCVOID)ctx->luaStatePtrAddr, &state, sizeof(state), &read);
+        if (state && state != lastState) {
+            debug_log("lua_State changed; registering natives");
+            for (const auto& f : ctx->funcs) {
+                registerFunction(ctx->process, f, state, ctx->registerFunc);
+            }
+            lastState = state;
+        }
+        if (WaitForSingleObject(ctx->process, 0) != WAIT_TIMEOUT) {
+            break; // process exited
+        }
+        Sleep(1000);
+    }
+    return 0;
+}
+
 int main() {
     init_logging();
-    
-    // Check if we're running with elevated privileges
-    if (!isProcessElevated()) {
-        debug_log("WARNING: Process is not running with elevated privileges");
-        debug_log("This may prevent access to protected processes");
-    } else {
-        debug_log("Process is running with elevated privileges");
-    }
 
-    // Try to enable debug privileges
-    if (enableDebugPrivilege()) {
-        debug_log("Successfully enabled debug privileges");
-    } else {
-        debug_log("WARNING: Failed to enable debug privileges");
-        debug_log("This may prevent access to protected processes");
+    if (!enableDebugPrivilege()) {
+        debug_log("WARNING: could not enable debug privilege");
     }
-    
-    std::vector<Signature> sigs;
-    if (!loadSignatures("signatures.json", sigs)) {
-        close_logging();
-        return 1;
-    }
-    debug_log("loaded signatures" );
 
     // Try different common case variations of the process name
     std::vector<std::wstring> processNames = {
-        L"uosa.exe",
-        L"UOSA.exe",
-        L"Uosa.exe",
-        L"wine-uosa.exe",
-        L"wine-UOSA.exe"
-    };
-    
+        L"uosa.exe", L"UOSA.exe", L"Uosa.exe", L"wine-uosa.exe", L"wine-UOSA.exe"};
+
     DWORD pid = 0;
     for (const auto& name : processNames) {
         pid = findProcess(name);
         if (pid) break;
     }
-    
+
     if (!pid) {
         std::cerr << "UOSA.exe not running (checked various case combinations)\n";
         close_logging();
@@ -389,136 +499,90 @@ int main() {
     }
     debug_log("found UO process with PID " + std::to_string(pid));
 
-    // Try with full debug permissions first
-    HANDLE hProc = OpenProcess(PROCESS_ALL_ACCESS, FALSE, pid);
+    HANDLE hProc = OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION |
+                               PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION, FALSE, pid);
     if (!hProc) {
-        debug_log("failed to open process with full permissions, trying reduced permissions...");
-        hProc = OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_CREATE_THREAD | PROCESS_QUERY_INFORMATION, FALSE, pid);
-        if (!hProc) {
-            debug_log("failed to open process with reduced permissions, trying minimal permissions...");
-            hProc = OpenProcess(PROCESS_VM_READ | PROCESS_VM_WRITE | PROCESS_VM_OPERATION | PROCESS_QUERY_INFORMATION, FALSE, pid);
-            if (!hProc) {
-                std::cerr << "failed to open process (error code: " << GetLastError() << ")\n";
-                close_logging();
-                return 1;
-            }
-        }
+        std::cerr << "failed to open process (error code: " << GetLastError() << ")\n";
+        close_logging();
+        return 1;
     }
-    debug_log("attached to process");
 
-    // Skip console creation in Wine environment
-    // createRemoteConsole(hProc, pid);
+    createRemoteConsole(hProc, pid);
 
-    // Give more time for the process to fully load
-    debug_log("waiting for process to initialize (5 seconds)...");
-    Sleep(5000);
-
-    bool anyPatternFound = false;
-    
-    // Wait a bit longer for the process to initialize
-    debug_log("performing module enumeration check...");
-    DWORD needed;
-    HMODULE modules[1024];
-    if (!EnumProcessModules(hProc, modules, sizeof(modules), &needed)) {
-        debug_log("warning: EnumProcessModules failed, process might not be fully initialized");
-        Sleep(2000); // Wait a bit longer
+    uintptr_t regFunc = 0, callSite = 0;
+    if (!findRegisterLuaFunction(hProc, regFunc, callSite)) {
+        debug_log("failed to locate RegisterLuaFunction");
+        CloseHandle(hProc);
+        close_logging();
+        return 1;
     }
-    
+
+    uintptr_t luaStatePtrAddr = 0;
+    if (!findLuaStatePtr(hProc, luaStatePtrAddr)) {
+        debug_log("failed to locate LuaState global");
+        CloseHandle(hProc);
+        close_logging();
+        return 1;
+    }
+
+    std::vector<Signature> sigs;
+    if (!loadSignatures("signatures.json", sigs)) {
+        debug_log("failed to load signatures.json");
+        CloseHandle(hProc);
+        close_logging();
+        return 1;
+    }
+
+    struct RemoteAlloc { LPVOID addr; SIZE_T size; };
+    std::vector<RemoteAlloc> allocs;
+    std::vector<RemoteFuncInfo> funcs;
+
     for (auto& s : sigs) {
         PatternData pd = parsePattern(s.pattern);
-        uintptr_t addr = 0;
-        
-        debug_log("scanning for " + s.lua_name + " pattern");
-        debug_log("pattern size: " + std::to_string(pd.bytes.size()) + " bytes");
-        debug_log("mask: " + pd.mask);
-
-        // Try scanning up to 3 times with delays
-        for (int attempt = 1; attempt <= 3; attempt++) {
-            if (scanProcess(hProc, pd, addr)) {
-                s.address = addr;
-                debug_log("found " + s.lua_name + " at 0x" + [&]{std::ostringstream oss; oss<<std::hex<<addr; return oss.str();}());
-                anyPatternFound = true;
-                break;
-            }
-            
-            if (attempt < 3) {
-                debug_log("attempt " + std::to_string(attempt) + " failed, waiting before retry...");
-                Sleep(1000);
-            } else {
-                debug_log("failed to find pattern for " + s.lua_name + " after " + std::to_string(attempt) + " attempts");
-            }
+        if (!scanProcess(hProc, pd, s.address)) {
+            debug_log("pattern not found for " + s.lua_name);
+            continue;
         }
+
+        // allocate bridge
+        void* bridge = VirtualAllocEx(hProc, nullptr, bridge_template_len, MEM_COMMIT | MEM_RESERVE, PAGE_EXECUTE_READWRITE);
+        if (!bridge) continue;
+        std::vector<uint8_t> b(bridge_template, bridge_template + bridge_template_len);
+        *(uint32_t*)&b[BRIDGE_FUNC_OFF] = (uint32_t)s.address;
+        SIZE_T written = 0;
+        WriteProcessMemory(hProc, bridge, b.data(), b.size(), &written);
+
+        // allocate name string
+        void* name = VirtualAllocEx(hProc, nullptr, s.lua_name.size() + 1, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE);
+        if (!name) {
+            VirtualFreeEx(hProc, bridge, 0, MEM_RELEASE);
+            continue;
+        }
+        WriteProcessMemory(hProc, name, s.lua_name.c_str(), s.lua_name.size() + 1, &written);
+
+        funcs.push_back({ (uint32_t)(uintptr_t)name, (uint32_t)(uintptr_t)bridge });
+        allocs.push_back({ bridge, bridge_template_len });
+        allocs.push_back({ name, s.lua_name.size() + 1 });
     }
 
-    if (!anyPatternFound) {
-        debug_log("warning: no patterns were found, process memory might not be accessible");
-        // Don't try to inject if we couldn't find any patterns
+    MonitorContext ctx{ hProc, luaStatePtrAddr, regFunc, funcs };
+    HANDLE monThread = CreateThread(nullptr, 0, monitorThread, &ctx, 0, nullptr);
+    if (!monThread) {
+        debug_log("failed to create monitor thread");
+        for (auto& a : allocs) VirtualFreeEx(hProc, a.addr, 0, MEM_RELEASE);
         CloseHandle(hProc);
         close_logging();
         return 1;
     }
 
-    // Allocate space for stub + patch info
-    // First try to verify we can read the process memory
-    MEMORY_BASIC_INFORMATION mbi;
-    if (!VirtualQueryEx(hProc, (LPCVOID)0x400000, &mbi, sizeof(mbi))) {
-        debug_log("warning: VirtualQueryEx failed, process might not be fully loaded");
-        Sleep(1000); // Wait a bit and try again
-        if (!VirtualQueryEx(hProc, (LPCVOID)0x400000, &mbi, sizeof(mbi))) {
-            std::cerr << "cannot query process memory (error: " << GetLastError() << ")\n";
-            CloseHandle(hProc);
-            close_logging();
-            return 1;
-        }
-    }
+    debug_log("monitoring started - press Enter to quit");
+    std::cin.get();
+    ctx.running = false;
+    WaitForSingleObject(monThread, INFINITE);
+    CloseHandle(monThread);
 
-    // Allocate memory with more restrictive permissions first
-    SIZE_T totalSize = stub_bin_len;
-    void* remote = VirtualAllocEx(hProc, nullptr, totalSize, MEM_COMMIT|MEM_RESERVE, PAGE_READWRITE);
-    if (!remote) {
-        std::cerr << "memory allocation failed (error: " << GetLastError() << ")\n";
-        CloseHandle(hProc);
-        close_logging();
-        return 1;
-    }
-    debug_log("allocated remote memory");
-
-    // Write the stub
-    SIZE_T written = 0;
-    if (!WriteProcessMemory(hProc, remote, stub_bin, stub_bin_len, &written) || written != stub_bin_len) {
-        std::cerr << "failed to write memory (error: " << GetLastError() << ")\n";
-        VirtualFreeEx(hProc, remote, 0, MEM_RELEASE);
-        CloseHandle(hProc);
-        return 1;
-    }
-    debug_log("wrote stub to remote process");
-
-    // Change permissions to allow execution
-    DWORD oldProtect;
-    if (!VirtualProtectEx(hProc, remote, totalSize, PAGE_EXECUTE_READ, &oldProtect)) {
-        std::cerr << "failed to set memory permissions (error: " << GetLastError() << ")\n";
-        VirtualFreeEx(hProc, remote, 0, MEM_RELEASE);
-        CloseHandle(hProc);
-        return 1;
-    }
-
-    // Create the remote thread with proper error handling
-    HANDLE thread = CreateRemoteThread(hProc, nullptr, 0, (LPTHREAD_START_ROUTINE)remote, nullptr, 0, nullptr);
-    if (thread) {
-        debug_log("stub injected, waiting for completion");
-        if (WaitForSingleObject(thread, 5000) == WAIT_TIMEOUT) { // 5 second timeout
-            debug_log("warning: thread execution timed out");
-            TerminateThread(thread, 1);
-        }
-        CloseHandle(thread);
-    } else {
-        std::cerr << "CreateRemoteThread failed (error: " << GetLastError() << ")\n";
-    }
-
-    // Cleanup
-    VirtualFreeEx(hProc, remote, 0, MEM_RELEASE);
+    for (auto& a : allocs) VirtualFreeEx(hProc, a.addr, 0, MEM_RELEASE);
     CloseHandle(hProc);
-    debug_log("done");
     close_logging();
     return 0;
 }


### PR DESCRIPTION
## Summary
- make stub bridge jump to built-in function
- attach to running client and monitor lua_State
- auto re-register functions when UI reloads
- document persistent monitoring in README

## Testing
- `cmake ..`
- `cmake --build .` *(fails: x86_64-w64-mingw32-g++ missing)*

------
https://chatgpt.com/codex/tasks/task_e_687f748551608332bb76337e1fd6a9cf