### PR TITLE
Fix EAX preservation in hook stub

### DIFF
--- a/UOWalkPatch/src/stub_bin_templates.cpp
+++ b/UOWalkPatch/src/stub_bin_templates.cpp
@@ -54,8 +54,8 @@ const unsigned char hook_stub_template[] = {
     0x75, 0xE9,                   // jnz  loop
     0x5F,                         // done: pop edi
     0x5B,                         // pop ebx
-    0xB8, 0,0,0,0,                // mov  eax, return address (patched)
-    0xFF, 0xE0                    // jmp  eax
+    0x68, 0,0,0,0,                // push return address (patched)
+    0xC3                          // ret
 };
 
 const size_t hook_stub_template_len = sizeof(hook_stub_template);


### PR DESCRIPTION
## Summary
- adjust the hook stub so that the return value from `RegisterLuaFunction` is preserved

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: `windows.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68802122e7b88332ab95005068bfa890