### PR TITLE
Improve injector reliability

### DIFF
--- a/UOWalkPatch/CMakeLists.txt
+++ b/UOWalkPatch/CMakeLists.txt
@@ -76,9 +76,6 @@ target_link_options(UOWalkPatchDLL PRIVATE
         /MACHINE:X86
         /DEBUG:FULL
         /INCREMENTAL:NO
-        /DYNAMICBASE:NO
-        /FIXED
-        /BASE:0x10000000
         /OPT:NOREF
         /OPT:NOICF
         /NODEFAULTLIB:msvcrt.lib
@@ -90,9 +87,6 @@ target_link_options(UOWalkPatchDLL PRIVATE
         /MACHINE:X86
         /DEBUG
         /INCREMENTAL:NO
-        /DYNAMICBASE:NO
-        /FIXED
-        /BASE:0x10000000
         /OPT:REF
         /OPT:ICF
         /NODEFAULTLIB:msvcrt.lib

--- a/UOWalkPatch/README.md
+++ b/UOWalkPatch/README.md
@@ -20,3 +20,9 @@ captures the internal `lua_State*` and registers any natives described in
 Reloading the UI will trigger the hook again so the functions remain available.
 A debug console pops up showing pattern matches and other status messages.
 Press **Enter** to exit the helper.
+
+## Troubleshooting
+
+If injection fails with a generic `LoadLibrary` error, ensure `signatures.json`
+is present in the same directory as `UOWalkPatchDLL.dll`. The DLL refuses to
+load when this file is missing.

--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -173,7 +173,11 @@ static BOOL InitializeDLLSafe(HMODULE hModule) {
         GetModuleFileNameA(hModule, sigPath, MAX_PATH);
         char* lastSlash = strrchr(sigPath, '\\');
         if (lastSlash) {
-            strcpy_s(lastSlash + 1, MAX_PATH - (lastSlash - sigPath), "signatures.json");
+            // `strcpy_s` requires the destination buffer size starting from the
+            // provided pointer. The previous calculation overshot by one and
+            // corrupted the stack when the path was at the end of the buffer.
+            size_t remaining = MAX_PATH - static_cast<size_t>(lastSlash - sigPath) - 1;
+            strcpy_s(lastSlash + 1, remaining, "signatures.json");
             
             WriteRawLog("Looking for signatures.json...");
             sprintf_s(buffer, sizeof(buffer), "Checking: %s", sigPath);

--- a/UOWalkPatch/src/injector.cpp
+++ b/UOWalkPatch/src/injector.cpp
@@ -155,12 +155,20 @@ static bool ValidateProcess(HANDLE hProcess) {
 
 static bool InjectHandle(HANDLE hProc, const std::wstring& dllPath) {
     std::wcout << L"Validating process..." << std::endl;
-    
+
     // Give the process a bit more time to initialize
     Sleep(3000);
     
     if (!ValidateProcess(hProc)) {
         std::wcerr << L"Process validation failed" << std::endl;
+        return false;
+    }
+
+    // Verify signatures.json exists next to the DLL
+    std::filesystem::path sigPath = std::filesystem::path(dllPath).parent_path() / L"signatures.json";
+    if (!std::filesystem::exists(sigPath)) {
+        std::wcerr << L"signatures.json not found: " << sigPath.wstring() << std::endl;
+        std::wcerr << L"Make sure this file is located next to the DLL" << std::endl;
         return false;
     }
 


### PR DESCRIPTION
## Summary
- remove fixed base flags so the DLL can relocate if the preferred address is unavailable
- check for `signatures.json` before injecting and warn if missing
- document the requirement for `signatures.json` in the injector README
- fix stack corruption in DLL initialization when building the signatures path

## Testing
- `cmake ../..` *(fails: windows headers missing)*
- `cmake --build .` *(fails: windows headers missing)*
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_688122f6ffcc83328a910ff3fa616d1d