### PR TITLE
Fix early guard page setup for global state pointer

### DIFF
--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -208,7 +208,17 @@ static void* FindGlobalStateInfo() {
                                 continue;
 
                             GlobalStateInfo* info = *(GlobalStateInfo**)addrOfPtr;
-                            if (!info) continue;
+
+                            // addrOfPtr = &staticGlobalStatePtr
+                            g_globalStateSlot = (DWORD*)addrOfPtr;
+                            if (g_globalStateSlot)
+                                InstallWriteWatch();        // arm guard page immediately
+
+                            if (!info)              // pointer not initialised yet
+                            {
+                                WriteRawLog("GlobalState pointer slot found but still NULL");
+                                return nullptr;      // let caller know we did not get the struct yet
+                            }
 
                             __try {
                                 if (info->luaState && info->databaseManager) {


### PR DESCRIPTION
## Summary
- detect the global state pointer slot even when it is null
- install the guard page as soon as the slot address is found

## Testing
- `cmake ..`
- `make` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_6884d5cec0008332a479ef98a6748600