### PR TITLE
Add walk function registration

### DIFF
--- a/UOWalkPatch/README.md
+++ b/UOWalkPatch/README.md
@@ -30,6 +30,13 @@ Press **Enter** to exit the helper.
 All debug output is also written to `uowalkpatch_debug.log`. The file is created
 next to the DLL if possible, otherwise in `%WINDIR%\Temp`.
 
+## Lua functions
+
+The patch exposes a couple of helper calls to Lua. `DummyPrint` simply logs a
+message, while the new `walk` command triggers the client's internal movement
+routine. The functions are registered automatically when the helper locates the
+client's Lua state.
+
 ## Troubleshooting
 
 If injection fails with a generic `LoadLibrary` error, ensure `signatures.json`


### PR DESCRIPTION
## Summary
- register new Lua function `walk`
- locate walk function and movement component using pattern scanning
- invoke network walk function when Lua `walk` is called
- document the Lua functions in README

## Testing
- `cmake ..` runs successfully
- `make` fails due to missing `windows.h` in the build environment

------
https://chatgpt.com/codex/tasks/task_e_6888ec0f03c48332aea5018a57b913ce