### PR TITLE
Capture movement component dynamically

### DIFF
--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -66,12 +66,18 @@ static LPVOID FindRegisterLuaFunction();
 static void InstallWriteWatch();
 static int  __cdecl Lua_DummyPrint(void* L);           // our Lua C‑function
 static void RegisterOurLuaFunctions();                  // one‑shot registrar
+static bool CallClientRegister(void* L, void* func, const char* name);
 // New walk function support
 typedef bool(__thiscall* WalkFunc_t)(void* thisPtr, uint8_t dir, uint8_t run);
 static WalkFunc_t g_walkFunc = nullptr;
+static WalkFunc_t g_origWalk = nullptr;   // original walk function
 static void* g_moveComp = nullptr;
+static bool  g_walkRegistered = false;    // true once Lua walk helper added
 static int  __cdecl Lua_Walk(void* L);
 static void InitWalkFunction();
+static bool InstallWalkHook();
+static bool __fastcall Hook_Walk(void* thisPtr, void* edx, uint8_t dir, uint8_t run);
+static void TryRegisterWalkFunction();
 
 static int __cdecl Lua_DummyPrint(void* L)
 {
@@ -184,6 +190,22 @@ static BYTE* FindPatternText(const char* sig)
 }
 
 // Locate walk function and movement component pointer
+static bool InstallWalkHook()
+{
+    if (!g_walkFunc) return false;
+
+    if (MH_CreateHook(g_walkFunc, &Hook_Walk, reinterpret_cast<LPVOID*>(&g_origWalk)) != MH_OK) {
+        WriteRawLog("MH_CreateHook failed for walk function");
+        return false;
+    }
+    if (MH_EnableHook(g_walkFunc) != MH_OK) {
+        WriteRawLog("MH_EnableHook failed for walk function");
+        return false;
+    }
+    WriteRawLog("Walk function hook installed");
+    return true;
+}
+
 static void InitWalkFunction()
 {
     MODULEINFO mi{};
@@ -204,6 +226,7 @@ static void InitWalkFunction()
         char buf[64];
         sprintf_s(buf, sizeof(buf), "Found walk function at %p", hit);
         WriteRawLog(buf);
+        InstallWalkHook();
     } else {
         WriteRawLog("Walk function not found");
     }
@@ -235,6 +258,43 @@ static int __cdecl Lua_Walk(void* L)
         WriteRawLog("walk function not initialized");
     }
     return 0;
+}
+
+// Register the Lua walk helper if prerequisites are met
+static void TryRegisterWalkFunction()
+{
+    if (g_walkRegistered || !g_walkFunc || !g_moveComp || !g_luaState || !g_origRegLua)
+        return;
+
+    const char* walkName = "walk";
+    WriteRawLog("Registering walk Lua function...");
+    if (CallClientRegister(g_luaState, reinterpret_cast<void*>(Lua_Walk), walkName)) {
+        char buf[128];
+        sprintf_s(buf, sizeof(buf),
+                  "Successfully registered Lua function '%s' (%p)",
+                  walkName, Lua_Walk);
+        WriteRawLog(buf);
+        g_walkRegistered = true;
+    } else {
+        WriteRawLog("!! Failed to register walk function");
+    }
+}
+
+// Hook to capture the movement component pointer on first use
+static bool __fastcall Hook_Walk(void* thisPtr, void* edx, uint8_t dir, uint8_t run)
+{
+    if (g_moveComp != thisPtr) {
+        g_moveComp = thisPtr;
+        char buf[64];
+        sprintf_s(buf, sizeof(buf), "Captured MoveComp pointer %p", thisPtr);
+        WriteRawLog(buf);
+        // Now that we have the pointer, attempt registration
+        TryRegisterWalkFunction();
+    }
+
+    if (g_origWalk)
+        return g_origWalk(thisPtr, dir, run);
+    return false;
 }
 
 static void* FindGlobalStateInfo() {
@@ -624,26 +684,8 @@ static void RegisterOurLuaFunctions()
         WriteRawLog("!! Failed to register DummyPrint");
     }
 
-    // Register walk function if we located it
-    if (g_walkFunc && g_moveComp) {
-        const char* walkName = "walk";
-        WriteRawLog("Registering walk Lua function...");
-        if (CallClientRegister(g_luaState,
-            reinterpret_cast<void*>(Lua_Walk),
-            walkName))
-        {
-            char buf[128];
-            sprintf_s(buf, sizeof(buf),
-                "Successfully registered Lua function '%s' (%p)",
-                walkName, Lua_Walk);
-            WriteRawLog(buf);
-        }
-        else {
-            WriteRawLog("!! Failed to register walk function");
-        }
-    } else {
-        WriteRawLog("walk function not found - skipping registration");
-    }
+    // Register walk function if we have everything needed already
+    TryRegisterWalkFunction();
 
     WriteRawLog("RegisterOurLuaFunctions completed");
 }


### PR DESCRIPTION
## Summary
- hook the client's walk function to capture the movement component pointer
- install the hook when the walk routine is found
- register the Lua `walk` function after the pointer becomes known
- declare `CallClientRegister` prototype to fix build error

## Testing
- ❌ `make -C UOWalkPatch/build` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_688900a2c5c48332aed640bbe09ed949