### PR TITLE
Implement safe one-time hook removal

### DIFF
--- a/UOWalkPatch/README.md
+++ b/UOWalkPatch/README.md
@@ -34,8 +34,9 @@ next to the DLL if possible, otherwise in `%WINDIR%\Temp`.
 
 The patch exposes a couple of helper calls to Lua. `DummyPrint` simply logs a
 message, while the new `walk` command triggers the client's internal movement
-routine. The functions are registered automatically when the helper locates the
-client's Lua state.
+routine. `UOWalkPatchTick` should be called each frame from Lua to allow the
+helper to clean up its temporary hook. The functions are registered
+automatically when the helper locates the client's Lua state.
 
 ## Troubleshooting
 

--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <atomic>
 #include "minhook.h"
 
 // Global state structure based on the memory layout observed
@@ -33,6 +34,8 @@ static HMODULE g_hModule;
 static GlobalStateInfo* g_globalStateInfo;
 static void* g_luaState;
 static HANDLE g_scanThread;
+static std::atomic<bool> g_needDisable{false};
+static std::atomic<bool> g_hookDisabled{false};
 
 // The client uses __stdcall for RegisterLuaFunction 
 typedef bool(__stdcall* RegisterLuaFunction_t)(void* luaState, void* func, const char* name);
@@ -87,8 +90,7 @@ static UpdateState_t g_origUpdate = nullptr;
 static bool InstallUpdateHook();
 static void InitUpdateFunction();
 static uint32_t __stdcall Hook_Update(uint32_t dataStruct, uint32_t targetDir, int32_t isRun);
-static long g_updateLogCount = 0;
-static thread_local int g_updateDepth = 0;  // re-entrancy guard
+
 
 // Helper with printf-style formatting
 static void Logf(const char* fmt, ...)
@@ -397,38 +399,33 @@ static void InitUpdateFunction()
 
 static uint32_t __stdcall Hook_Update(uint32_t dataStruct, uint32_t targetDir, int32_t isRun)
 {
-    if (++g_updateDepth > 1) {
-        uint32_t r = g_origUpdate ? g_origUpdate(dataStruct, targetDir, isRun) : 0;
-        --g_updateDepth;
-        return r;
-    }
+    if (g_hookDisabled.load(std::memory_order_relaxed))
+        return g_origUpdate(dataStruct, targetDir, isRun);
 
-    if (g_updateLogCount < 50)
-        Logf("updateState: dir=%u run=%d", targetDir, isRun);
-    else if (g_updateLogCount == 50)
-        WriteRawLog("updateState: throttling logs...");
-    g_updateLogCount++;
-
-    if (g_moveComp != (void*)dataStruct) {
+    if (!g_moveComp) {
         g_moveComp = (void*)dataStruct;
-        Logf("Captured MoveComp @ %p (from updateState)", g_moveComp);
+        Logf("MoveComp captured = %p", g_moveComp);
+        g_needDisable.store(true, std::memory_order_release);
     }
 
-    __try {
-        struct Vec3 { int x, y, z; };
-        Vec3* cur = (Vec3*)(dataStruct + 0x44);
-        Logf("CurPos x=%d y=%d z=%d", cur->x, cur->y, cur->z);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        WriteRawLog("Exception reading position in Hook_Update");
+    return g_origUpdate(dataStruct, targetDir, isRun);
+}
+
+static void OnFrame()
+{
+    if (g_needDisable.exchange(false, std::memory_order_acquire))
+    {
+        MH_DisableHook(g_updateState);
+        MH_RemoveHook(g_updateState);
+        g_hookDisabled.store(true, std::memory_order_release);
+        WriteRawLog("updateState detour removed safely");
     }
+}
 
-    uint32_t ret = g_origUpdate ? g_origUpdate(dataStruct, targetDir, isRun) : 0;
-
-    if (g_updateLogCount <= 50)
-        Logf("updateState ret=%u", ret);
-
-    --g_updateDepth;
-    return ret;
+static int __cdecl Lua_Tick(void* /*L*/)
+{
+    OnFrame();
+    return 0;
 }
 
 static void* FindGlobalStateInfo() {
@@ -816,6 +813,23 @@ static void RegisterOurLuaFunctions()
     else
     {
         WriteRawLog("!! Failed to register DummyPrint");
+    }
+
+    // Register tick function for per-frame cleanup
+    const char* tickName = "UOWalkPatchTick";
+    if (CallClientRegister(g_luaState,
+        reinterpret_cast<void*>(Lua_Tick),
+        tickName))
+    {
+        char buf[128];
+        sprintf_s(buf, sizeof(buf),
+            "Registered Lua function '%s' (%p)",
+            tickName, Lua_Tick);
+        WriteRawLog(buf);
+    }
+    else
+    {
+        WriteRawLog("!! Failed to register tick function");
     }
 
     // Existing walk hook disabled; updateState hook handles capture now


### PR DESCRIPTION
## Summary
- capture the movement component once when `updateDataStructureState` runs
- add a per-frame Lua tick to disable the hook safely
- document `UOWalkPatchTick` in README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68897cfdb21883329ddd5186b707df61