### PR TITLE
Implement safe detour cleanup

### DIFF
--- a/UOFlow/Interface.lua
+++ b/UOFlow/Interface.lua
@@ -948,10 +948,15 @@ end
 -------------------------------------------------------------------------------
 
 function Interface.Update( timePassed )
-		
 
-	ok, err = pcall(StatusWindow.EnableInput, timePassed)	
+	if UOWalkPatchOnFrame then
+	ok, err = pcall(UOWalkPatchOnFrame)
 	Interface.ErrorTracker(ok, err)
+	end
+
+
+ok, err = pcall(StatusWindow.EnableInput, timePassed)
+Interface.ErrorTracker(ok, err)
 	
 	ok, err = pcall(Interface.UpdateLatency, timePassed)	
 	Interface.ErrorTracker(ok, err)


### PR DESCRIPTION
## Summary
- add atomic flags to track detour state
- update `Hook_Update` to capture once and signal cleanup
- implement `OnFrame` and Lua bridge to disable hook safely
- register the new Lua function
- call the hook cleanup each frame from Lua

## Testing
- `cmake ..` and `cmake --build .` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_68897cfdb21883329ddd5186b707df61