### PR TITLE
Implement safe one-time unhook pattern

### DIFF
--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -6,6 +6,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
+#include <atomic>
 #include "minhook.h"
 
 // Global state structure based on the memory layout observed
@@ -66,6 +67,8 @@ static DWORD WINAPI WaitForLua(LPVOID param);
 static LPVOID FindRegisterLuaFunction();
 static void InstallWriteWatch();
 static int  __cdecl Lua_DummyPrint(void* L);           // our Lua C‑function
+static int  __cdecl Lua_OnFrame(void* L);             // frame callback from Lua
+static void OnFrame();                                // engine thread callback
 static void RegisterOurLuaFunctions();                  // one‑shot registrar
 static bool CallClientRegister(void* L, void* func, const char* name);
 // New walk function support
@@ -87,8 +90,8 @@ static UpdateState_t g_origUpdate = nullptr;
 static bool InstallUpdateHook();
 static void InitUpdateFunction();
 static uint32_t __stdcall Hook_Update(uint32_t dataStruct, uint32_t targetDir, int32_t isRun);
-static long g_updateLogCount = 0;
-static thread_local int g_updateDepth = 0;  // re-entrancy guard
+static std::atomic<bool> g_needDisable{false};   // set inside detour
+static std::atomic<bool> g_hookDisabled{false};  // once disabled, skip detour
 
 // Helper with printf-style formatting
 static void Logf(const char* fmt, ...)
@@ -397,38 +400,33 @@ static void InitUpdateFunction()
 
 static uint32_t __stdcall Hook_Update(uint32_t dataStruct, uint32_t targetDir, int32_t isRun)
 {
-    if (++g_updateDepth > 1) {
-        uint32_t r = g_origUpdate ? g_origUpdate(dataStruct, targetDir, isRun) : 0;
-        --g_updateDepth;
-        return r;
+    if (g_hookDisabled.load(std::memory_order_relaxed))
+        return g_origUpdate ? g_origUpdate(dataStruct, targetDir, isRun) : 0;
+
+    if (!g_moveComp) {
+        g_moveComp = reinterpret_cast<void*>(dataStruct);
+        Logf("MoveComp captured = %p", g_moveComp);
+        g_needDisable.store(true, std::memory_order_release);
     }
 
-    if (g_updateLogCount < 50)
-        Logf("updateState: dir=%u run=%d", targetDir, isRun);
-    else if (g_updateLogCount == 50)
-        WriteRawLog("updateState: throttling logs...");
-    g_updateLogCount++;
+    return g_origUpdate ? g_origUpdate(dataStruct, targetDir, isRun) : 0;
+}
 
-    if (g_moveComp != (void*)dataStruct) {
-        g_moveComp = (void*)dataStruct;
-        Logf("Captured MoveComp @ %p (from updateState)", g_moveComp);
+static void OnFrame()
+{
+    if (g_needDisable.exchange(false, std::memory_order_acquire))
+    {
+        MH_DisableHook(g_updateState);
+        MH_RemoveHook(g_updateState);      // optional: free trampoline
+        g_hookDisabled.store(true, std::memory_order_release);
+        WriteRawLog("updateState detour removed safely");
     }
+}
 
-    __try {
-        struct Vec3 { int x, y, z; };
-        Vec3* cur = (Vec3*)(dataStruct + 0x44);
-        Logf("CurPos x=%d y=%d z=%d", cur->x, cur->y, cur->z);
-    } __except (EXCEPTION_EXECUTE_HANDLER) {
-        WriteRawLog("Exception reading position in Hook_Update");
-    }
-
-    uint32_t ret = g_origUpdate ? g_origUpdate(dataStruct, targetDir, isRun) : 0;
-
-    if (g_updateLogCount <= 50)
-        Logf("updateState ret=%u", ret);
-
-    --g_updateDepth;
-    return ret;
+static int __cdecl Lua_OnFrame(void*)
+{
+    OnFrame();
+    return 0;
 }
 
 static void* FindGlobalStateInfo() {
@@ -811,11 +809,29 @@ static void RegisterOurLuaFunctions()
             "Successfully registered Lua function '%s' (%p)",
             luaName, Lua_DummyPrint);
         WriteRawLog(buf);
-        done = true;
     }
     else
     {
         WriteRawLog("!! Failed to register DummyPrint");
+    }
+
+    // Register OnFrame callback used to disable hooks
+    const char* frameName = "UOWP_OnFrame";
+    WriteRawLog("Registering OnFrame Lua function...");
+    if (CallClientRegister(g_luaState,
+        reinterpret_cast<void*>(Lua_OnFrame),
+        frameName))
+    {
+        char buf[128];
+        sprintf_s(buf, sizeof(buf),
+            "Successfully registered Lua function '%s' (%p)",
+            frameName, Lua_OnFrame);
+        WriteRawLog(buf);
+        done = true;
+    }
+    else
+    {
+        WriteRawLog("!! Failed to register OnFrame function");
     }
 
     // Existing walk hook disabled; updateState hook handles capture now


### PR DESCRIPTION
## Summary
- add atomic flags to manage unhooking
- simplify Hook_Update to capture the movement component once
- add `OnFrame` helper and Lua wrapper
- register new Lua function `UOWP_OnFrame`

## Testing
- `cmake ..` *(fails: windows.h not found)*
- `make` *(fails: windows.h not found)*

------
https://chatgpt.com/codex/tasks/task_e_68897cfdb21883329ddd5186b707df61