### PR TITLE
Fix update hook calling convention

### DIFF
--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -78,8 +78,9 @@ static void FindMoveComponent();
 static volatile LONG g_needWalkReg = 0;  // 0 = no, 1 = register when safe
 
 // New updateDataStructureState hook
-typedef uint32_t (__stdcall* UpdateState_t)(
-    uint32_t  moveComp,
+// real prototype: this in ECX, remaining args on the stack
+typedef uint32_t (__thiscall* UpdateState_t)(
+    void*     moveComp,
     uint32_t  dir,
     int       runFlag);
 static UpdateState_t g_updateState = nullptr;
@@ -90,7 +91,11 @@ static long g_updateLogCount = 0;  // Log up to ~200 calls for telemetry
 static thread_local int g_updateDepth = 0;  // re-entrancy guard
 static std::atomic_flag g_regBusy = ATOMIC_FLAG_INIT;
 static HANDLE g_regThread = nullptr;
-static uint32_t __stdcall H_Update(uint32_t moveComp, uint32_t dir, int runFlag);
+// use __fastcall so ECX==this, EDX is free scratch
+static uint32_t __fastcall H_Update(void*     moveComp,
+                                    void*     /*edx*/,
+                                    uint32_t  dir,
+                                    int       runFlag);
 
 // Helper with printf-style formatting
 static void Logf(const char* fmt, ...)
@@ -280,17 +285,13 @@ static void FindMoveComponent()
     WriteRawLog("Move component not found via scan");
 }
 
-typedef uint32_t (__stdcall* UpdateState_stdcall)(uint32_t moveComp,
-                                                 uint32_t dir,
-                                                 int runFlag);
-
 static int __cdecl Lua_Walk(void* L)
 {
     if (g_moveComp && g_origUpdate)
     {
         __try {
-            auto fn = reinterpret_cast<UpdateState_stdcall>(g_origUpdate);
-            fn(static_cast<uint32_t>(reinterpret_cast<uintptr_t>(g_moveComp)), 0u, 0);
+            auto fn = reinterpret_cast<UpdateState_t>(g_origUpdate);
+            fn(g_moveComp, 0u, 0);          // ECX=this, stack=(dir,run)
         } __except (EXCEPTION_EXECUTE_HANDLER) {
             WriteRawLog("Exception calling updateState");
         }
@@ -301,11 +302,11 @@ static int __cdecl Lua_Walk(void* L)
     return 0;
 }
 
-static uint32_t __stdcall H_Update(uint32_t thisPtr, uint32_t dir, int run)
+static uint32_t __fastcall H_Update(void* moveComp, void* /*edx*/, uint32_t dir, int runFlag)
 {
     if (!g_moveComp && InterlockedCompareExchange(&g_haveMoveComp, 1, 0) == 0)
     {
-        g_moveComp = reinterpret_cast<void*>(static_cast<uintptr_t>(thisPtr));
+        g_moveComp = moveComp;
         DWORD tid = GetCurrentThreadId();
         Logf("Captured moveComp = %p (thread %lu)", g_moveComp, tid);
         InterlockedExchange(&g_needWalkReg, 1);
@@ -314,12 +315,12 @@ static uint32_t __stdcall H_Update(uint32_t thisPtr, uint32_t dir, int run)
     if (g_updateDepth++ == 0) {
         if (g_updateLogCount < 200) {
             Logf("updateState(this=%p, dir=%u, run=%d)",
-                 (void*)(uintptr_t)thisPtr, dir, run);
+                 moveComp, dir, runFlag);
             ++g_updateLogCount;
         }
     }
 
-    uint32_t ret = g_origUpdate(thisPtr, dir, run);
+    uint32_t ret = g_origUpdate(moveComp, dir, runFlag);
     --g_updateDepth;
 
     // Safe point outside client code; check for deferred registration


### PR DESCRIPTION
## Summary
- correct `updateDataStructureState` prototype to __thiscall and adjust hook to __fastcall
- update Lua helper to call original routine with proper ECX-based `this`

## Testing
- `cmake .. && make` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688a97c1e8c4833281df92c0d1dd03ec