### PR TITLE
Expose sendRaw Lua function via Winsock send hook

### DIFF
--- a/UOWalkPatch/README.md
+++ b/UOWalkPatch/README.md
@@ -33,9 +33,9 @@ next to the DLL if possible, otherwise in `%WINDIR%\Temp`.
 ## Lua functions
 
 The patch exposes a couple of helper calls to Lua. `DummyPrint` simply logs a
-message, while the new `walk` command triggers the client's internal movement
-routine. The functions are registered automatically when the helper locates the
-client's Lua state.
+message, `walk` triggers the client's internal movement routine, and `sendRaw`
+forwards a byte string through the client's network layer. The functions are
+registered automatically when the helper locates the client's Lua state.
 
 ## Troubleshooting
 

--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -2,12 +2,16 @@
 #define WIN32_LEAN_AND_MEAN
 #endif
 #include <windows.h>
+#include <winsock2.h>
 #include <psapi.h>
 #include <stdint.h>
 #include <stdio.h>
 #include <stdarg.h>
 #include <atomic>
 #include <minhook.h>
+#include <intrin.h>
+
+extern "C" const char* lua_tolstring(void* L, int idx, size_t* len);
 
 // Global state structure based on the memory layout observed
 struct GlobalStateInfo {
@@ -73,6 +77,9 @@ static DWORD WINAPI RegisterThread(LPVOID);             // worker for deferred r
 static void* g_moveComp = nullptr; // movement component instance
 static int  __cdecl Lua_Walk(void* L);
 static void FindMoveComponent();
+static int  __cdecl Lua_SendRaw(void* L);
+static void InstallSendHook();
+static int WSAAPI H_Send(SOCKET s, const char* buf, int len, int flags);
 
 // Deferred Lua registration state
 static volatile LONG g_needWalkReg = 0;  // 0 = no, 1 = register when safe
@@ -98,6 +105,10 @@ static uint32_t __fastcall H_Update(void* thisPtr,  // ECX
     uint32_t dir,
     int     runFlag);
 static void* g_dest;
+using SendPacket_t = void(__thiscall*)(void* netMgr, const void* pkt, int len);
+static SendPacket_t g_sendPacket = nullptr;
+static void* g_netMgr = nullptr;
+static int (WSAAPI* g_real_send)(SOCKET s, const char* buf, int len, int flags) = nullptr;
 
 // Helper with printf-style formatting
 static void Logf(const char* fmt, ...)
@@ -121,6 +132,18 @@ static bool IsOnCurrentStack(void* p)
 {
     NT_TIB* tib = reinterpret_cast<NT_TIB*>(NtCurrentTeb());
     return p >= tib->StackLimit && p < tib->StackBase;
+}
+
+// Heuristic scan backwards for a typical function prologue
+static void* FindFuncStart(void* retAddr)
+{
+    BYTE* p = static_cast<BYTE*>(retAddr);
+    for (int i = 1; i < 64; ++i)
+    {
+        if (p[-i] == 0x55 && p[-i + 1] == 0x8B && p[-i + 2] == 0xEC)
+            return p - i;
+    }
+    return nullptr;
 }
 
 // Simple memory search helper
@@ -309,6 +332,21 @@ static int __cdecl Lua_Walk(void* L)
     return 0;
 }
 
+static int __cdecl Lua_SendRaw(void* L)
+{
+    size_t len = 0;
+    const char* bytes = lua_tolstring(L, 1, &len);
+    if (len > 0 && g_sendPacket && g_netMgr)
+    {
+        g_sendPacket(g_netMgr, bytes, static_cast<int>(len));
+    }
+    else
+    {
+        WriteRawLog("sendRaw() called before prerequisites were ready");
+    }
+    return 0;
+}
+
 
 static uint32_t __fastcall H_Update(void* thisPtr,  // ECX
     void* _unused,  // EDX
@@ -339,6 +377,53 @@ static uint32_t __fastcall H_Update(void* thisPtr,  // ECX
     return rc;
 }
 
+// ---------------------------------------------------------------------------
+// send() hook
+// ---------------------------------------------------------------------------
+
+static int WSAAPI H_Send(SOCKET s, const char* buf, int len, int flags)
+{
+    void* caller = _ReturnAddress();
+    MEMORY_BASIC_INFORMATION mbi{};
+    HMODULE exe = GetModuleHandleA(nullptr);
+    if (exe && VirtualQuery(caller, &mbi, sizeof(mbi)) && mbi.AllocationBase == exe)
+    {
+        Logf("send called from %p  (len=%d, id=%02X)", caller, len, (unsigned char)buf[0]);
+        if (!g_sendPacket)
+            g_sendPacket = reinterpret_cast<SendPacket_t>(FindFuncStart(caller));
+        if (!g_netMgr)
+        {
+#if defined(_MSC_VER)
+            __asm mov g_netMgr, ecx
+#else
+            __asm__("mov %0, %%ecx" : "=r"(g_netMgr));
+#endif
+        }
+        if (g_sendPacket && g_netMgr)
+            RegisterOurLuaFunctions();
+    }
+    return g_real_send ? g_real_send(s, buf, len, flags) : 0;
+}
+
+static void InstallSendHook()
+{
+    HMODULE ws = GetModuleHandleA("ws2_32.dll");
+    if (!ws)
+        ws = LoadLibraryA("ws2_32.dll");
+    if (!ws)
+        return;
+    void* target = GetProcAddress(ws, "send");
+    if (target &&
+        MH_CreateHook(target, &H_Send, reinterpret_cast<LPVOID*>(&g_real_send)) == MH_OK &&
+        MH_EnableHook(target) == MH_OK)
+    {
+        WriteRawLog("send hook installed");
+    }
+    else
+    {
+        WriteRawLog("send hook failed");
+    }
+}
 
 // ---------------------------------------------------------------------------
 // updateDataStructureState hook
@@ -758,6 +843,7 @@ static void RegisterOurLuaFunctions()
 {
     static bool dummyReg = false;
     static bool walkReg = false;
+    static bool sendReg = false;
     if (!g_luaState || !g_origRegLua)
         return;
 
@@ -796,6 +882,18 @@ static void RegisterOurLuaFunctions()
     }
     else if (!g_moveComp && !walkReg) {
         WriteRawLog("walk function prerequisites missing");
+    }
+
+    if (g_sendPacket && g_netMgr && !sendReg) {
+        const char* sendName = "sendRaw";
+        WriteRawLog("Registering sendRaw Lua function...");
+        bool ok = CallClientRegister(g_luaState,
+            reinterpret_cast<void*>(Lua_SendRaw), sendName);
+        WriteRawLog(ok ? "Successfully registered sendRaw()" :
+            "!! Register sendRaw() failed");
+        if (ok) {
+            sendReg = true;
+        }
     }
 
 
@@ -942,8 +1040,9 @@ static BOOL InitializeDLLSafe(HMODULE hModule) {
         }
         WriteRawLog("MinHook initialized successfully");
 
-        // Install update hook once
+        // Install hooks
         InstallUpdateHook();
+        InstallSendHook();
 
         // Start background thread to scan for Lua state
         g_scanThread = CreateThread(nullptr, 0, WaitForLua, nullptr, 0, nullptr);


### PR DESCRIPTION
## Summary
- hook ws2_32!send to log packet origin and capture network manager
- add sendRaw Lua native calling the game's packet-sending wrapper
- document sendRaw helper in README

## Testing
- `cmake ..`
- `cmake --build .` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e1aced8c08332a26732d408745432