### PR TITLE
Expose SendRaw packet helper via Winsock send hooks

### DIFF
--- a/UOWalkPatch/README.md
+++ b/UOWalkPatch/README.md
@@ -33,9 +33,13 @@ next to the DLL if possible, otherwise in `%WINDIR%\Temp`.
 ## Lua functions
 
 The patch exposes a couple of helper calls to Lua. `DummyPrint` simply logs a
-message, while the new `walk` command triggers the client's internal movement
-routine. The functions are registered automatically when the helper locates the
-client's Lua state.
+message and `walk` triggers the client's internal movement routine. For sending
+arbitrary packets without Lua, the DLL exports a `SendRaw` function that
+forwards a byte buffer through the client's network layer. Internally the DLL
+hooks the Winsock send-family (`send`, `WSASend`, `WSASendTo`, `sendto`) to
+surface the game's packet wrapper and capture the network manager pointer. The
+Lua functions are registered automatically when the helper locates the client's
+Lua state.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary
- export `SendRaw` helper to forward bytes via the game's packet wrapper
- drop Lua dependency for raw packet sending and initialize log handle safely
- hook all Winsock send-family functions to capture packet wrapper automatically
- document `SendRaw` usage and the Winsock hooks in README

## Testing
- `cmake ..`
- `cmake --build .` *(fails: fatal error: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e1aced8c08332a26732d408745432