### PR TITLE
Add runtime SendBuilder hooks

### DIFF
--- a/UOWalkPatch/CMakeLists.txt
+++ b/UOWalkPatch/CMakeLists.txt
@@ -54,11 +54,12 @@ target_include_directories(UOWalkPatchDLL PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}/src
 )
 
-target_link_libraries(UOWalkPatchDLL PRIVATE 
+target_link_libraries(UOWalkPatchDLL PRIVATE
     minhook
     psapi
     kernel32
     user32
+    dbghelp
 )
 
 # Set DLL properties


### PR DESCRIPTION
## Summary
- log SendBuilder call stacks using MinHook detours
- initialize symbol handler and clean up on unload
- link dbghelp for symbol resolution

## Testing
- `cmake -S UOWalkPatch -B build`
- `cmake --build build` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_688e5023d278833281e59292f515b255