### PR TITLE
Replace Lua walk queue with packet send

### DIFF
--- a/UOWalkPatch/src/dllmain.cpp
+++ b/UOWalkPatch/src/dllmain.cpp
@@ -384,8 +384,11 @@ typedef uint32_t(__stdcall* UpdateState_stdcall)(uint32_t moveComp,
 
 static int __cdecl Lua_Walk(void* /*L*/)
 {
-    g_pendingRun.store(2, std::memory_order_relaxed); // run
-    g_pendingDir.store(4, std::memory_order_relaxed); // east
+    // Instead of queuing a direction for the update hook, build and
+    // transmit a movement packet directly. This bypasses the game's
+    // internal movement component and relies on our network hook.
+
+    SendWalk(4, 1); // run east
     return 0;
 }
 


### PR DESCRIPTION
## Summary
- Send walk packets directly from `Lua_Walk` instead of queuing movement

## Testing
- `cmake --build .` *(fails: windows.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6891539e7e5483328b58d91e7cada553