### PR TITLE
Replace Lua walk queue with packet send

### DIFF
--- a/UOWalkPatch/CMakeLists.txt
+++ b/UOWalkPatch/CMakeLists.txt
@@ -60,6 +60,7 @@ target_link_libraries(UOWalkPatchDLL PRIVATE
     kernel32
     user32
     dbghelp
+    ws2_32
 )
 
 # Set DLL properties


### PR DESCRIPTION
## Summary
- Parse Lua `walk` arguments and forward them to a new `SendWalk` helper
- Build 0x02 walk packets with fast-walk keys and update the client's position immediately after sending
- Remove the old pending-walk queue so the movement hook only registers Lua helpers

## Testing
- `cmake -S UOWalkPatch -B build`
- `cmake --build build` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6891539e7e5483328b58d91e7cada553