### PR TITLE
Delay-load LuaPlus and load with altered search path

### DIFF
--- a/UOWalkPatch/CMakeLists.txt
+++ b/UOWalkPatch/CMakeLists.txt
@@ -96,8 +96,12 @@ target_link_libraries(UOWalkPatchDLL PRIVATE
     dbghelp
     ws2_32
     ${LUAPLUS_LIBRARY}
+    delayimp
 )
 add_dependencies(UOWalkPatchDLL luaplus_import_lib)
+
+# Delay-load LuaPlus so it can be loaded manually from our directory
+target_link_options(UOWalkPatchDLL PRIVATE "/DELAYLOAD:luaplus_1100.dll")
 
 # Set DLL properties
 set_target_properties(UOWalkPatchDLL PROPERTIES


### PR DESCRIPTION
## Summary
- Delay-load luaplus_1100.dll so it can be loaded at runtime
- Explicitly load LuaPlus with LoadLibraryEx and keep it loaded

## Testing
- `cmake -S UOWalkPatch -B build` *(fails: Could not find VS_LIB_EXE using the following names: lib)*

------
https://chatgpt.com/codex/tasks/task_e_689a410e348483329a2e30c81d415c88