### PR TITLE
Register Lua helpers without hooking RegisterLuaFunction

### DIFF
--- a/UOWalkPatch/include/Engine/GlobalState.hpp
+++ b/UOWalkPatch/include/Engine/GlobalState.hpp
@@ -22,6 +22,5 @@ namespace Engine {
     void ReportLuaState(void* L);
     void* LuaState();
     const GlobalStateInfo* Info();
-    void* FindRegisterLuaFunction();
 }
 


### PR DESCRIPTION
## Summary
- stop hooking the client's RegisterLuaFunction helper
- register DummyPrint and walk using the Lua C API
- invoke Lua helper registration when the Lua state becomes available

## Testing
- `cmake ..` *(fails: Could not find VS_LIB_EXE using the following names: lib)*

------
https://chatgpt.com/codex/tasks/task_e_689a8639503c83328ab3dcd789b29774