### PR TITLE
Reset Lua registration on new state

### DIFF
--- a/UOWalkPatch/src/Engine/GlobalState.cpp
+++ b/UOWalkPatch/src/Engine/GlobalState.cpp
@@ -364,12 +364,13 @@ void ShutdownGlobalStateWatch() {
 }
 
 void ReportLuaState(void* L) {
-    if (g_luaState) return;
+    if (!L || g_luaState == L)
+        return;
 
     g_luaState = L;
     g_luaStateCaptured = true;
     char buffer[128];
-    sprintf_s(buffer, sizeof(buffer), "Captured first Lua state @ %p", L);
+    sprintf_s(buffer, sizeof(buffer), "Captured Lua state @ %p", L);
     WriteRawLog(buffer);
 
     g_globalStateInfo = (GlobalStateInfo*)FindOwnerOfLuaState(L);

--- a/UOWalkPatch/src/Engine/LuaBridge.cpp
+++ b/UOWalkPatch/src/Engine/LuaBridge.cpp
@@ -45,9 +45,16 @@ void RegisterOurLuaFunctions()
 {
     static bool dummyReg = false;
     static bool walkReg = false;
+    static lua_State* lastState = nullptr;
     auto L = static_cast<lua_State*>(Engine::LuaState());
     if (!L)
         return;
+
+    if (L != lastState) {
+        dummyReg = false;
+        walkReg = false;
+        lastState = L;
+    }
 
     if (!dummyReg) {
         WriteRawLog("Registering DummyPrint Lua function...");


### PR DESCRIPTION
## Summary
- reset registration flags when Lua state changes to re-register DummyPrint and walk
- re-register Lua helpers when new Lua state captured and request walk registration

## Testing
- `cmake -S UOWalkPatch -B build` *(fails: Could not find VS_LIB_EXE using the following names: lib)*

------
https://chatgpt.com/codex/tasks/task_e_689a8aa930608332b2cc61c0cebb5bb0