### PR TITLE
Handle Lua state resets

### DIFF
--- a/UOWalkPatch/src/Engine/GlobalState.cpp
+++ b/UOWalkPatch/src/Engine/GlobalState.cpp
@@ -327,7 +327,7 @@ static DWORD WINAPI WaitForLua(LPVOID) {
             sprintf_s(buffer, sizeof(buffer), "Scanner found Lua State @ %p", g_luaState);
             WriteRawLog(buffer);
 
-            Lua::RegisterOurLuaFunctions();
+            // Queue Lua helper registration for the next safe point
             RequestWalkRegistration();
 
             return 0;
@@ -383,7 +383,7 @@ void ReportLuaState(void* L) {
         }
     }
 
-    Lua::RegisterOurLuaFunctions();
+    // The Lua VM was recreated; request re-registration of helpers
     RequestWalkRegistration();
 }
 

--- a/UOWalkPatch/src/Engine/LuaBridge.cpp
+++ b/UOWalkPatch/src/Engine/LuaBridge.cpp
@@ -54,6 +54,7 @@ void RegisterOurLuaFunctions()
         dummyReg = false;
         walkReg = false;
         lastState = L;
+        WriteRawLog("Lua state changed; reset registration flags");
     }
 
     if (!dummyReg) {


### PR DESCRIPTION
## Summary
- Reset Lua helper registration flags whenever a new Lua state is detected and log the change
- Defer Lua helper registration by queuing a walk registration when a new Lua state is found

## Testing
- `cmake -S UOWalkPatch -B build` *(fails: Could not find VS_LIB_EXE)*

------
https://chatgpt.com/codex/tasks/task_e_689a8d9559708332a3bb8c04cd69f4be