### PR TITLE
Handle Lua state resets

### DIFF
--- a/UOWalkPatch/src/Engine/GlobalState.cpp
+++ b/UOWalkPatch/src/Engine/GlobalState.cpp
@@ -327,7 +327,7 @@ static DWORD WINAPI WaitForLua(LPVOID) {
             sprintf_s(buffer, sizeof(buffer), "Scanner found Lua State @ %p", g_luaState);
             WriteRawLog(buffer);
 
-            Lua::RegisterOurLuaFunctions();
+            // Queue Lua helper registration for the next safe point
             RequestWalkRegistration();
 
             return 0;
@@ -383,7 +383,7 @@ void ReportLuaState(void* L) {
         }
     }
 
-    Lua::RegisterOurLuaFunctions();
+    // The Lua VM was recreated; request re-registration of helpers
     RequestWalkRegistration();
 }
 

--- a/UOWalkPatch/src/Engine/LuaBridge.cpp
+++ b/UOWalkPatch/src/Engine/LuaBridge.cpp
@@ -46,32 +46,37 @@ void RegisterOurLuaFunctions()
     static bool dummyReg = false;
     static bool walkReg = false;
     static lua_State* lastState = nullptr;
+    static bool lastMovementReady = false;
     auto L = static_cast<lua_State*>(Engine::LuaState());
     if (!L)
         return;
 
-    if (L != lastState) {
+    bool movementReady = Engine::MovementReady();
+
+    if (L != lastState || movementReady != lastMovementReady) {
         dummyReg = false;
         walkReg = false;
         lastState = L;
+        lastMovementReady = movementReady;
+        WriteRawLog("Lua or movement state changed; reset registration flags");
     }
 
     if (!dummyReg) {
         WriteRawLog("Registering DummyPrint Lua function...");
         lua_pushcfunction(L, Lua_DummyPrint);
         lua_setglobal(L, "DummyPrint");
-        WriteRawLog("Successfully registered Lua function 'DummyPrint'");
+        WriteRawLog("Successfully registered DummyPrint");
         dummyReg = true;
     }
 
-    if (Engine::MovementReady() && !walkReg) {
+    if (movementReady && !walkReg) {
         WriteRawLog("Registering walk Lua function...");
         lua_pushcfunction(L, Lua_Walk);
         lua_setglobal(L, "walk");
-        WriteRawLog("Successfully registered walk()");
+        WriteRawLog("Successfully registered walk");
         walkReg = true;
     }
-    else if (!Engine::MovementReady() && !walkReg) {
+    else if (!movementReady && !walkReg) {
         WriteRawLog("walk function prerequisites missing");
     }
     WriteRawLog("RegisterOurLuaFunctions completed");


### PR DESCRIPTION
## Summary
- Reset Lua helper registration when Lua state or movement readiness changes
- Register DummyPrint and walk helpers with `lua_pushcfunction`

## Testing
- `cmake -S UOWalkPatch -B build` *(fails: Could not find VS_LIB_EXE)*

------
https://chatgpt.com/codex/tasks/task_e_689a8d9559708332a3bb8c04cd69f4be